### PR TITLE
fixing the environment building

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - ghp-import=0.5.5=py36_0
 - ipython=6.2.1=py36_1
-- nbconvert=5.3.1=py_1
+- nbconvert=5.3.1
 - markdown=2.6.11=py_0
 - pip:
   - "--editable=git+https://github.com/getpelican/pelican.git@72756a5#egg=pelican"


### PR DESCRIPTION
The simpliest way for me to make it work was to suppress the =py_1 at the end of the nbconvert version tag. I'm very new to conda environment, so I'm not sure what this "=py_1" is used for, and I couldnot find any informations about it. 